### PR TITLE
Small docker-compose and nginx docs fixes.

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -26,6 +26,8 @@ services:
       - env
     volumes:
       - ./data:/data
+    port:
+      - "3000:3000"
 ```
 
 A `env` file is needed where all of the environmental variables are defined.

--- a/docs/install/reverse-proxy/nginx.md
+++ b/docs/install/reverse-proxy/nginx.md
@@ -48,7 +48,6 @@ server {
       proxy_read_timeout 1d;
       proxy_send_timeout 1d;
     }
-  }
 }
 ```
 


### PR DESCRIPTION
While going through the installation process on my server, I noticed two small problems with the installation docs:

- The docker-compose example file was missing a ports configuration.
- The nginx configuration had an extra '}' at the end.

This pull request fixes these two problems.